### PR TITLE
:bug: fix(shell): hide debug console and fix title bar double-click

### DIFF
--- a/src/MarkMello.Desktop/MarkMello.Desktop.csproj
+++ b/src/MarkMello.Desktop/MarkMello.Desktop.csproj
@@ -11,10 +11,6 @@
     <MarkMelloReleaseRepo Condition="'$(MarkMelloReleaseRepo)' == ''">MarkMello</MarkMelloReleaseRepo>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-
   <PropertyGroup Condition="'$(PublishAot)' == 'true'">
     <InvariantGlobalization>false</InvariantGlobalization>
   </PropertyGroup>

--- a/src/MarkMello.Presentation/Views/MainWindow.axaml.cs
+++ b/src/MarkMello.Presentation/Views/MainWindow.axaml.cs
@@ -182,12 +182,32 @@ public partial class MainWindow : Window
 
     private void OnTitleBarPointerPressed(object? sender, PointerPressedEventArgs e)
     {
-        if (!_viewModel.ShowCustomTitleBar || e.ClickCount != 1)
+        if (!_viewModel.ShowCustomTitleBar)
         {
             return;
         }
 
         if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+        {
+            return;
+        }
+
+        // Double-click on the custom title bar toggles Maximized/Normal,
+        // mirroring native Windows chrome behaviour.
+        if (e.ClickCount == 2)
+        {
+            if (CanResize)
+            {
+                WindowState = WindowState == WindowState.Maximized
+                    ? WindowState.Normal
+                    : WindowState.Maximized;
+            }
+
+            e.Handled = true;
+            return;
+        }
+
+        if (e.ClickCount != 1)
         {
             return;
         }


### PR DESCRIPTION
Two small, independent fixes for the desktop shell window.

## 1. Hide console window on Debug startup (`MarkMello.Desktop.csproj`)

Removed the Debug-only `OutputType=Exe` override; `WinExe` is now
used for all configurations. On Windows this prevented a console
window from being attached during Debug runs. `Console.Error.WriteLine`
calls (used in `InitializeStartupAsync`) keep working — Windows just
does not attach a visible console to a `WinExe` binary.

## 2. Toggle Maximize on title bar double-click (`MainWindow.axaml.cs`)

`OnTitleBarPointerPressed` returned early when `ClickCount != 1`, so
a double-click on the custom title bar was silently dropped. Added a
`ClickCount == 2` branch that toggles `WindowState` between `Maximized`
and `Normal`, gated on `CanResize`, mirroring `OnMaximizeClick` logic.
Single-click drag via `BeginMoveDrag` is preserved.

The custom title bar path is only active on Windows
(`ConfigurePlatformChrome` enables it via
`ExtendClientAreaToDecorationsHint` + `WindowDecorations.BorderOnly`),
so macOS and Linux are unaffected.

## Testing

Verified locally on Windows: no console window appears on Debug
startup, double-click on the title bar maximizes/restores correctly,
single-click drag and the Maximize button still work. Existing tests
under `tests/` do not cover either path; no test changes were made.

If you prefer reviewing these separately, happy to split into two PRs.