### PR TITLE
:bug: fix(window): anchor maximize to current screen on multi-monitor

### DIFF
--- a/src/MarkMello.Presentation/Views/MainWindow.axaml.cs
+++ b/src/MarkMello.Presentation/Views/MainWindow.axaml.cs
@@ -174,9 +174,7 @@ public partial class MainWindow : Window
         => WindowState = WindowState.Minimized;
 
     private void OnMaximizeClick(object? sender, RoutedEventArgs e)
-        => WindowState = WindowState == WindowState.Maximized
-            ? WindowState.Normal
-            : WindowState.Maximized;
+        => ToggleMaximizedWindowState();
 
     private void OnCloseClick(object? sender, RoutedEventArgs e) => Close();
 
@@ -198,9 +196,7 @@ public partial class MainWindow : Window
         {
             if (CanResize)
             {
-                WindowState = WindowState == WindowState.Maximized
-                    ? WindowState.Normal
-                    : WindowState.Maximized;
+                ToggleMaximizedWindowState();
             }
 
             e.Handled = true;
@@ -380,6 +376,116 @@ public partial class MainWindow : Window
 
     private void OnWindowPositionChanged(object? sender, PixelPointEventArgs e)
         => CaptureLastNormalWindowPlacement();
+
+    /// <summary>
+    /// Переключает окно между Maximized и Normal.
+    /// На Windows с extended client area + BorderOnly chrome (Avalonia 12) native
+    /// maximize в multi-monitor setup (особенно при разной ориентации мониторов)
+    /// иногда вычисляет MAXPOSITION/MAXSIZE относительно другого монитора, чем тот,
+    /// на котором фактически находится окно. Перед переходом в Maximized "якорим"
+    /// normal-границы окна целиком внутри WorkingArea текущего экрана — тогда
+    /// MonitorFromWindow в Win32 надёжно выберет нужный монитор.
+    /// </summary>
+    private void ToggleMaximizedWindowState()
+    {
+        if (WindowState == WindowState.Maximized)
+        {
+            WindowState = WindowState.Normal;
+            return;
+        }
+
+        if (OperatingSystem.IsWindows())
+        {
+            AnchorWindowToCurrentScreenBeforeMaximize();
+        }
+
+        WindowState = WindowState.Maximized;
+    }
+
+    private void AnchorWindowToCurrentScreenBeforeMaximize()
+    {
+        if (WindowState != WindowState.Normal)
+        {
+            return;
+        }
+
+        var screen = TryGetCurrentScreen();
+        if (screen is null)
+        {
+            return;
+        }
+
+        var anchoredPlacement = CalculateAnchoredNormalPlacement(
+            Position,
+            Width,
+            Height,
+            screen.WorkingArea,
+            screen.Scaling,
+            MinWidth,
+            MinHeight,
+            DefaultWindowWidth,
+            DefaultWindowHeight);
+
+        Position = new PixelPoint(
+            (int)Math.Round(anchoredPlacement.X),
+            (int)Math.Round(anchoredPlacement.Y));
+        Width = anchoredPlacement.Width;
+        Height = anchoredPlacement.Height;
+    }
+
+    private Screen? TryGetCurrentScreen()
+    {
+        try
+        {
+            return Screens.ScreenFromPoint(Position) ?? Screens.Primary;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Возвращает normal-placement, гарантированно умещающийся внутри переданного
+    /// WorkingArea с учётом scaling. Используется для "якоря" окна на нужном мониторе
+    /// перед native maximize, см. <see cref="ToggleMaximizedWindowState"/>.
+    /// </summary>
+    internal static WindowPlacement CalculateAnchoredNormalPlacement(
+        PixelPoint currentPosition,
+        double currentWidth,
+        double currentHeight,
+        PixelRect workingArea,
+        double screenScaling,
+        double minWidth,
+        double minHeight,
+        double defaultWidth,
+        double defaultHeight)
+    {
+        var scaling = screenScaling > 0 && !double.IsNaN(screenScaling) && !double.IsInfinity(screenScaling)
+            ? screenScaling
+            : 1;
+
+        var width = currentWidth > 0 && !double.IsNaN(currentWidth) && !double.IsInfinity(currentWidth)
+            ? currentWidth
+            : Math.Max(minWidth, defaultWidth);
+        var height = currentHeight > 0 && !double.IsNaN(currentHeight) && !double.IsInfinity(currentHeight)
+            ? currentHeight
+            : Math.Max(minHeight, defaultHeight);
+
+        var maxWidth = Math.Max(minWidth, (workingArea.Width - WindowPlacementMarginPixels * 2) / scaling);
+        var maxHeight = Math.Max(minHeight, (workingArea.Height - WindowPlacementMarginPixels * 2) / scaling);
+
+        width = Math.Clamp(width, minWidth, maxWidth);
+        height = Math.Clamp(height, minHeight, maxHeight);
+
+        var widthPixels = Math.Max(1, (int)Math.Ceiling(width * scaling));
+        var heightPixels = Math.Max(1, (int)Math.Ceiling(height * scaling));
+
+        var x = ClampToWorkingRange(currentPosition.X, workingArea.X, workingArea.Width, widthPixels);
+        var y = ClampToWorkingRange(currentPosition.Y, workingArea.Y, workingArea.Height, heightPixels);
+
+        return new WindowPlacement(x, y, width, height, IsMaximized: false);
+    }
 
     private void ApplyStartupWindowPlacement()
     {

--- a/tests/MarkMello.Presentation.Tests/MainWindowPlacementTests.cs
+++ b/tests/MarkMello.Presentation.Tests/MainWindowPlacementTests.cs
@@ -63,4 +63,122 @@ public sealed class MainWindowPlacementTests
         Assert.Equal(1200d, placement.Width);
         Assert.Equal(800d, placement.Height);
     }
+
+    [Fact]
+    public void CalculateAnchoredNormalPlacementKeepsPositionWhenWindowAlreadyInsideTargetScreen()
+    {
+        // Secondary monitor positioned right of primary.
+        var workingArea = new PixelRect(1920, 0, 2560, 1440);
+
+        var placement = MainWindow.CalculateAnchoredNormalPlacement(
+            currentPosition: new PixelPoint(2200, 200),
+            currentWidth: 1280,
+            currentHeight: 840,
+            workingArea,
+            screenScaling: 1,
+            minWidth: 640,
+            minHeight: 480,
+            defaultWidth: 1280,
+            defaultHeight: 840);
+
+        Assert.Equal(2200d, placement.X);
+        Assert.Equal(200d, placement.Y);
+        Assert.Equal(1280d, placement.Width);
+        Assert.Equal(840d, placement.Height);
+        Assert.False(placement.IsMaximized);
+    }
+
+    [Fact]
+    public void CalculateAnchoredNormalPlacementClampsWindowSpanningTwoMonitorsBackToTargetScreen()
+    {
+        // Window sits at (1800,200), spilling out of primary (0..1920) onto secondary (1920..4480).
+        // Caller decides target = secondary; placement must end up entirely within secondary.
+        var secondaryWorkingArea = new PixelRect(1920, 0, 2560, 1440);
+
+        var placement = MainWindow.CalculateAnchoredNormalPlacement(
+            currentPosition: new PixelPoint(1800, 200),
+            currentWidth: 1280,
+            currentHeight: 840,
+            secondaryWorkingArea,
+            screenScaling: 1,
+            minWidth: 640,
+            minHeight: 480,
+            defaultWidth: 1280,
+            defaultHeight: 840);
+
+        Assert.True(placement.X >= secondaryWorkingArea.X);
+        Assert.True(placement.X + placement.Width <= secondaryWorkingArea.X + secondaryWorkingArea.Width);
+        Assert.True(placement.Y >= secondaryWorkingArea.Y);
+        Assert.True(placement.Y + placement.Height <= secondaryWorkingArea.Y + secondaryWorkingArea.Height);
+        Assert.False(placement.IsMaximized);
+    }
+
+    [Fact]
+    public void CalculateAnchoredNormalPlacementShrinksWindowToFitPortraitMonitor()
+    {
+        // Portrait monitor placed to the left of primary: 1080x1920 at (-1080, 0).
+        var portraitWorkingArea = new PixelRect(-1080, 0, 1080, 1920);
+
+        var placement = MainWindow.CalculateAnchoredNormalPlacement(
+            currentPosition: new PixelPoint(-200, 500),
+            currentWidth: 1280,
+            currentHeight: 840,
+            portraitWorkingArea,
+            screenScaling: 1,
+            minWidth: 640,
+            minHeight: 480,
+            defaultWidth: 1280,
+            defaultHeight: 840);
+
+        Assert.True(placement.Width <= portraitWorkingArea.Width);
+        Assert.True(placement.X >= portraitWorkingArea.X);
+        Assert.True(placement.X + placement.Width <= portraitWorkingArea.X + portraitWorkingArea.Width);
+        Assert.True(placement.Y >= portraitWorkingArea.Y);
+        Assert.False(placement.IsMaximized);
+    }
+
+    [Fact]
+    public void CalculateAnchoredNormalPlacementHonoursScalingWhenSizingToWorkingArea()
+    {
+        // 4K monitor at 200% scaling — usable DIPs = 1920x1080.
+        var workingArea = new PixelRect(3840, 0, 3840, 2160);
+
+        var placement = MainWindow.CalculateAnchoredNormalPlacement(
+            currentPosition: new PixelPoint(3900, 80),
+            currentWidth: 5000, // bigger than available DIPs — must shrink
+            currentHeight: 3000,
+            workingArea,
+            screenScaling: 2,
+            minWidth: 640,
+            minHeight: 480,
+            defaultWidth: 1280,
+            defaultHeight: 840);
+
+        Assert.True(placement.Width * 2 <= workingArea.Width);
+        Assert.True(placement.Height * 2 <= workingArea.Height);
+        Assert.True(placement.X >= workingArea.X);
+        Assert.True(placement.Y >= workingArea.Y);
+        Assert.False(placement.IsMaximized);
+    }
+
+    [Fact]
+    public void CalculateAnchoredNormalPlacementFallsBackToDefaultsForInvalidSize()
+    {
+        var workingArea = new PixelRect(0, 0, 1920, 1080);
+
+        var placement = MainWindow.CalculateAnchoredNormalPlacement(
+            currentPosition: new PixelPoint(50, 50),
+            currentWidth: double.NaN,
+            currentHeight: double.NegativeInfinity,
+            workingArea,
+            screenScaling: 1,
+            minWidth: 640,
+            minHeight: 480,
+            defaultWidth: 1280,
+            defaultHeight: 840);
+
+        Assert.Equal(1280d, placement.Width);
+        Assert.Equal(840d, placement.Height);
+        Assert.False(placement.IsMaximized);
+    }
 }


### PR DESCRIPTION
Closes #7.

## Summary
- Window jumped to a wrong monitor on `WindowState = Maximized` in multi-monitor setups (most reliably with mixed orientation, e.g. a portrait monitor next to landscape).
- On Windows with extended client area + `BorderOnly` chrome, the toggle previously fired a plain `WindowState = Maximized` with no constraint on the window's normal bounds, so the native `WM_GETMINMAXINFO` handler / `MonitorFromWindow` could resolve to a different monitor than the visible one.

## Fix
- Centralised maximize/restore through `ToggleMaximizedWindowState()` (called from both `OnMaximizeClick` and the title-bar double-click handler).
- On Windows, before transitioning to Maximized, the window's normal bounds are "anchored" entirely inside the current `Screen.WorkingArea` (with the same margin and scaling rules as the existing startup-placement path). After that, native maximize resolves the current monitor unambiguously.
- Bounds math lives in a pure static `MainWindow.CalculateAnchoredNormalPlacement(...)`, mirroring the existing `CalculateStartupWindowPlacement` pattern for testability.
- No-op on macOS / Linux: those paths still use native maximize.

## Tests
Added under `MainWindowPlacementTests` in the same style as existing tests:

- `CalculateAnchoredNormalPlacementKeepsPositionWhenWindowAlreadyInsideTargetScreen`
- `CalculateAnchoredNormalPlacementClampsWindowSpanningTwoMonitorsBackToTargetScreen`
- `CalculateAnchoredNormalPlacementShrinksWindowToFitPortraitMonitor` — covers the negative-X portrait-on-the-left layout from the issue
- `CalculateAnchoredNormalPlacementHonoursScalingWhenSizingToWorkingArea` — 4K @ 200%
- `CalculateAnchoredNormalPlacementFallsBackToDefaultsForInvalidSize` — NaN/Infinity guards

## Test plan
- [x] `dotnet build MarkMello.sln -c Release` — 0 warnings / 0 errors (TreatWarningsAsErrors)
- [x] `dotnet test MarkMello.sln -c Release` — 203 / 203 passing (18 Domain + 185 Presentation; 5 are new)
- [ ] Reporter to verify manually on the 3-monitor portrait+landscape setup from #7

## Notes
- The "anchor" step also implicitly updates `_lastNormalWindowPlacement` via the existing `SizeChanged` / `PositionChanged` handlers, so restoring from Maximized brings the window back to the anchored position on the correct monitor (consistent with native Windows behaviour).
- Win+Up / OS-driven snap is not routed through this toggle and is therefore not changed by this PR.