### PR TITLE
:bug: fix(window): manual maximize on Windows for multi-monitor (#7)

### DIFF
--- a/src/MarkMello.Presentation/Views/MainWindow.axaml.cs
+++ b/src/MarkMello.Presentation/Views/MainWindow.axaml.cs
@@ -26,6 +26,7 @@ public partial class MainWindow : Window
     private readonly Task _startupInitializationTask = Task.CompletedTask;
     private WindowPlacement? _lastNormalWindowPlacement;
     private bool _allowConfirmedClose;
+    private bool _manuallyMaximized;
 
     public MainWindow()
     {
@@ -174,9 +175,7 @@ public partial class MainWindow : Window
         => WindowState = WindowState.Minimized;
 
     private void OnMaximizeClick(object? sender, RoutedEventArgs e)
-        => WindowState = WindowState == WindowState.Maximized
-            ? WindowState.Normal
-            : WindowState.Maximized;
+        => ToggleMaximizedWindowState();
 
     private void OnCloseClick(object? sender, RoutedEventArgs e) => Close();
 
@@ -198,9 +197,7 @@ public partial class MainWindow : Window
         {
             if (CanResize)
             {
-                WindowState = WindowState == WindowState.Maximized
-                    ? WindowState.Normal
-                    : WindowState.Maximized;
+                ToggleMaximizedWindowState();
             }
 
             e.Handled = true;
@@ -381,6 +378,130 @@ public partial class MainWindow : Window
     private void OnWindowPositionChanged(object? sender, PixelPointEventArgs e)
         => CaptureLastNormalWindowPlacement();
 
+    /// <summary>
+    /// Переключает окно между развёрнутым и обычным состоянием.
+    /// На Windows native <c>WindowState.Maximized</c> при extended client area
+    /// + BorderOnly chrome (Avalonia 12) в multi-monitor конфигурации может взять
+    /// ширину virtual screen (сумма мониторов), оставив окно "разорванным" на
+    /// несколько экранов. Чтобы обойти это, на Windows выполняется "ручной"
+    /// maximize: <see cref="WindowState"/> остаётся Normal, а Position/Width/Height
+    /// явно выставляются по <see cref="Screen.WorkingArea"/> текущего экрана.
+    /// На других платформах используется native maximize.
+    /// </summary>
+    private void ToggleMaximizedWindowState()
+    {
+        if (_manuallyMaximized)
+        {
+            RestoreFromManualMaximize();
+            return;
+        }
+
+        if (WindowState == WindowState.Maximized)
+        {
+            WindowState = WindowState.Normal;
+            return;
+        }
+
+        if (OperatingSystem.IsWindows() && TryApplyManualMaximize())
+        {
+            return;
+        }
+
+        WindowState = WindowState.Maximized;
+    }
+
+    private bool TryApplyManualMaximize()
+    {
+        var screen = TryGetCurrentScreen();
+        if (screen is null)
+        {
+            return false;
+        }
+
+        return ApplyManualMaximize(screen);
+    }
+
+    private bool ApplyManualMaximize(Screen screen)
+    {
+        // Снимок текущих normal-bounds для последующего restore. _lastNormalWindowPlacement
+        // также используется в персистентности (см. CreateWindowPlacementForPersistence).
+        _lastNormalWindowPlacement = CaptureCurrentNormalWindowPlacement();
+
+        var maxPlacement = CalculateManualMaximizePlacement(
+            screen.WorkingArea,
+            screen.Scaling,
+            MinWidth,
+            MinHeight);
+
+        // Флаг ставим ДО изменения bounds — обработчики Size/Position changed
+        // используют его как guard в CaptureLastNormalWindowPlacement, чтобы
+        // не затереть нормальное расположение нашими maximize-границами.
+        _manuallyMaximized = true;
+        Position = new PixelPoint(
+            (int)Math.Round(maxPlacement.X),
+            (int)Math.Round(maxPlacement.Y));
+        Width = maxPlacement.Width;
+        Height = maxPlacement.Height;
+        return true;
+    }
+
+    private void RestoreFromManualMaximize()
+    {
+        var restore = _lastNormalWindowPlacement;
+        if (restore is null)
+        {
+            _manuallyMaximized = false;
+            return;
+        }
+
+        // Сначала меняем bounds, потом сбрасываем флаг — иначе CaptureLastNormalWindowPlacement
+        // получит уведомление от ещё незавершённого restore и запишет промежуточные значения.
+        Width = restore.Width;
+        Height = restore.Height;
+        Position = new PixelPoint(
+            (int)Math.Round(restore.X),
+            (int)Math.Round(restore.Y));
+        _manuallyMaximized = false;
+    }
+
+    private Screen? TryGetCurrentScreen()
+    {
+        try
+        {
+            return Screens.ScreenFromPoint(Position) ?? Screens.Primary;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Целевые границы окна для ручного maximize: целиком закрывает
+    /// <paramref name="workingArea"/> текущего экрана, конвертирует размеры из
+    /// пикселей в DIPs через <paramref name="screenScaling"/>.
+    /// </summary>
+    internal static WindowPlacement CalculateManualMaximizePlacement(
+        PixelRect workingArea,
+        double screenScaling,
+        double minWidth,
+        double minHeight)
+    {
+        var scaling = screenScaling > 0 && !double.IsNaN(screenScaling) && !double.IsInfinity(screenScaling)
+            ? screenScaling
+            : 1;
+
+        var width = Math.Max(minWidth, workingArea.Width / scaling);
+        var height = Math.Max(minHeight, workingArea.Height / scaling);
+
+        return new WindowPlacement(
+            workingArea.X,
+            workingArea.Y,
+            width,
+            height,
+            IsMaximized: true);
+    }
+
     private void ApplyStartupWindowPlacement()
     {
         var savedPlacement = LoadWindowPlacementBestEffort();
@@ -407,7 +528,16 @@ public partial class MainWindow : Window
 
         if (savedPlacement?.IsMaximized == true)
         {
-            WindowState = WindowState.Maximized;
+            if (OperatingSystem.IsWindows())
+            {
+                // На Windows native maximize в multi-monitor конфигурации ненадёжен —
+                // используем тот же ручной maximize, что и при toggle, см. ToggleMaximizedWindowState.
+                ApplyManualMaximize(screen);
+            }
+            else
+            {
+                WindowState = WindowState.Maximized;
+            }
         }
     }
 
@@ -523,7 +653,7 @@ public partial class MainWindow : Window
 
     private void CaptureLastNormalWindowPlacement()
     {
-        if (WindowState != WindowState.Normal)
+        if (WindowState != WindowState.Normal || _manuallyMaximized)
         {
             return;
         }
@@ -568,6 +698,12 @@ public partial class MainWindow : Window
 
     private WindowPlacement? CreateWindowPlacementForPersistence()
     {
+        if (_manuallyMaximized)
+        {
+            var manualRestore = _lastNormalWindowPlacement ?? CaptureCurrentNormalWindowPlacement();
+            return manualRestore with { IsMaximized = true };
+        }
+
         if (WindowState == WindowState.Normal)
         {
             return CaptureCurrentNormalWindowPlacement();

--- a/tests/MarkMello.Presentation.Tests/MainWindowPlacementTests.cs
+++ b/tests/MarkMello.Presentation.Tests/MainWindowPlacementTests.cs
@@ -63,4 +63,96 @@ public sealed class MainWindowPlacementTests
         Assert.Equal(1200d, placement.Width);
         Assert.Equal(800d, placement.Height);
     }
+
+    [Fact]
+    public void CalculateManualMaximizePlacementCoversPrimaryMonitorWorkingArea()
+    {
+        var workingArea = new PixelRect(0, 0, 1920, 1040);
+
+        var placement = MainWindow.CalculateManualMaximizePlacement(
+            workingArea,
+            screenScaling: 1,
+            minWidth: 640,
+            minHeight: 480);
+
+        Assert.Equal(0d, placement.X);
+        Assert.Equal(0d, placement.Y);
+        Assert.Equal(1920d, placement.Width);
+        Assert.Equal(1040d, placement.Height);
+        Assert.True(placement.IsMaximized);
+    }
+
+    [Fact]
+    public void CalculateManualMaximizePlacementAlignsToSecondaryMonitorOrigin()
+    {
+        // Secondary monitor to the right of primary: 2560x1440 at (1920, 0).
+        var workingArea = new PixelRect(1920, 0, 2560, 1440);
+
+        var placement = MainWindow.CalculateManualMaximizePlacement(
+            workingArea,
+            screenScaling: 1,
+            minWidth: 640,
+            minHeight: 480);
+
+        Assert.Equal(1920d, placement.X);
+        Assert.Equal(0d, placement.Y);
+        Assert.Equal(2560d, placement.Width);
+        Assert.Equal(1440d, placement.Height);
+        Assert.True(placement.IsMaximized);
+    }
+
+    [Fact]
+    public void CalculateManualMaximizePlacementHandlesPortraitMonitorWithNegativeXOrigin()
+    {
+        // Portrait monitor placed to the left of primary: 1080x1920 at (-1080, 0).
+        var workingArea = new PixelRect(-1080, 0, 1080, 1920);
+
+        var placement = MainWindow.CalculateManualMaximizePlacement(
+            workingArea,
+            screenScaling: 1,
+            minWidth: 640,
+            minHeight: 480);
+
+        Assert.Equal(-1080d, placement.X);
+        Assert.Equal(0d, placement.Y);
+        Assert.Equal(1080d, placement.Width);
+        Assert.Equal(1920d, placement.Height);
+        Assert.True(placement.IsMaximized);
+    }
+
+    [Fact]
+    public void CalculateManualMaximizePlacementConvertsPixelExtentToDipsWhenScaled()
+    {
+        // 4K monitor at 200% scaling — usable DIPs = 1920x1080.
+        var workingArea = new PixelRect(3840, 0, 3840, 2160);
+
+        var placement = MainWindow.CalculateManualMaximizePlacement(
+            workingArea,
+            screenScaling: 2,
+            minWidth: 640,
+            minHeight: 480);
+
+        Assert.Equal(3840d, placement.X);
+        Assert.Equal(0d, placement.Y);
+        Assert.Equal(1920d, placement.Width);
+        Assert.Equal(1080d, placement.Height);
+        Assert.True(placement.IsMaximized);
+    }
+
+    [Fact]
+    public void CalculateManualMaximizePlacementHonoursMinimumDimensionsForTinyMonitors()
+    {
+        // Hypothetical undersized monitor — width/height below the app minimums.
+        var workingArea = new PixelRect(0, 0, 400, 300);
+
+        var placement = MainWindow.CalculateManualMaximizePlacement(
+            workingArea,
+            screenScaling: 1,
+            minWidth: 640,
+            minHeight: 480);
+
+        Assert.Equal(640d, placement.Width);
+        Assert.Equal(480d, placement.Height);
+        Assert.True(placement.IsMaximized);
+    }
 }


### PR DESCRIPTION
Closes #7.

## Summary

- On Windows, replace native `WindowState = Maximized` with a manual maximize that sets `Position`/`Width`/`Height` to the current screen's `WorkingArea` while keeping `WindowState = Normal`.
- Fixes the multi-monitor "window splits across two screens" symptom on L-shaped layouts with mixed orientation (e.g. one portrait + two landscape).

## Root cause

With `ExtendClientAreaToDecorationsHint = true` + `WindowDecorations = BorderOnly`, Avalonia 12.0.1 on Windows defers to Win32 `WM_GETMINMAXINFO` / `MonitorFromWindow` to resolve the target monitor when going to `Maximized`. On an L-shaped virtual desktop with mixed monitor orientations those handlers can pick a different monitor than the one the window is visually on — the maximized window ends up with origin from one screen and extent sized for another.

## Fix

- `ToggleMaximizedWindowState()` — single entry point for the title-bar Maximize button and the title-bar double-click. On Windows it routes through `TryApplyManualMaximize()`; on other platforms it falls back to native `WindowState.Maximized`.
- `ApplyManualMaximize(Screen)` resolves the current screen via `Screens.ScreenFromPoint(Position)` and sets bounds explicitly. `Screens` is the Avalonia abstraction — we never call back into Win32 monitor APIs, so `MonitorFromWindow` cannot misroute the window.
- `_manuallyMaximized` flag guards `CaptureLastNormalWindowPlacement` so the maximize bounds do not overwrite the saved normal placement.
- Startup with a persisted `IsMaximized: true` placement follows the same manual path on Windows (otherwise the bug would also fire on first launch into a maximized state).
- Persistence (`CreateWindowPlacementForPersistence`) writes the saved normal bounds + `IsMaximized: true`, so a restart restores a correctly-positioned maximize.

Bounds math lives in pure static `MainWindow.CalculateManualMaximizePlacement(...)`, mirroring the existing `CalculateStartupWindowPlacement` pattern — same DPI / min-dimension handling, fully unit-testable without a window host.

**Trade-off:** no native Windows maximize animation. Acceptable with custom chrome, and required to keep the window on the correct monitor.

## Tests

Five new tests in `MainWindowPlacementTests` covering `CalculateManualMaximizePlacement`:

- Primary monitor at `(0, 0)`.
- Secondary monitor with positive X offset (right of primary).
- Portrait monitor with **negative X origin** (left of primary) — the configuration that triggers the bug.
- 4K monitor at 200% scaling (pixel extent → DIPs conversion).
- Undersized monitor smaller than `MinWidth`/`MinHeight` (minimums honoured).

Full local run: `dotnet test` — 203/203 passed (18 Domain + 185 Presentation).

## Test plan

- [x] Unit tests green (`dotnet test`).
- [x] Manual smoke on Windows 11 multi-monitor: 3 displays with one portrait monitor on an L-shaped layout — maximize from each monitor (button + double-click) keeps the window on the correct monitor.
- [x] Restore after manual maximize returns to the pre-maximize normal bounds.
- [x] Persisted maximized state restores on the correct monitor after restart.
- [ ] macOS / Linux unaffected (native maximize path unchanged).